### PR TITLE
100.2.3

### DIFF
--- a/assets/sass/main.sass
+++ b/assets/sass/main.sass
@@ -13,6 +13,7 @@
 @use 'src/button/hotkey'
 @use 'src/button/bs_btn'
 @use 'src/button/copy_code_btn'
+@use 'src/fonts/fonts'
 @include utils.init_tags()
 @include headers.init_headers()
 // @include headers.init_headers(null, (30, 20, 1.17, 1, 0.83, 0.67))
@@ -25,3 +26,4 @@
 @include hotkey.init_hotkey()
 @include bs_btn.init_bootstrap()
 @include copy_code_btn.init()
+@include fonts.init_google_fonts()

--- a/assets/sass/src/_headers.sass
+++ b/assets/sass/src/_headers.sass
@@ -27,9 +27,24 @@ $-font_size_list: 2, 1.5, 1.17, 1, 0.83, 0.67
       margin-left: 0
       margin-right: 0
       font-weight: bold
-      background-color: get_header_bk_color($i)
+      // background-color: get_header_color($i)
+      text-shadow: 1px 1px 0 #6d2959
 
-@function get_header_bk_color($layer)
+      @if $i != 1
+        color: #ec22c0
+
+      & a
+        text-decoration: none  // 取消下畫線
+        color: inherit!important  // 使用header本身的顏色。(hover的顏色也會被弄掉，所以如果要有hover的效果顏色要重弄，且如果這邊用的是important那麼hover也要用important才有辦法覆蓋)
+      & a:hover
+        color: #96CCFF!important
+
+      // 這招沒用，因為其他的h1-h6也都是在div內
+      // div &  // 想要讓header的shadow以及color只有在標題運用，在非標題所用到的header不套用此屬性
+      //  text-shadow: none
+      //  color: initial
+
+@function get_header_color($layer)
   @if $layer == 1
     @return initial
   @else

--- a/assets/sass/src/_headers.sass
+++ b/assets/sass/src/_headers.sass
@@ -48,9 +48,19 @@ $-font_size_list: 2, 1.5, 1.17, 1, 0.83, 0.67
       //  text-shadow: none
       //  color: initial
 
+  @keyframes highlight-target
+    from
+      background: inherit
+    50%
+      border: 2px solid #D4D4D4
+      background-color: #fff700
+    to
+      background: inherit
+      border: inherit
+
   :target  // 文章內連結點擊過去的目標屬性設置
-    border: 2px solid #D4D4D4
-    background-color: #e5eecc
+    // https://stackoverflow.com/questions/18894981/sass-not-scss-syntax-for-css3-keyframe-animation
+    -webkit-animation: highlight-target 2.0s linear
 
 @function get_header_color($layer)
   @if $layer == 1

--- a/assets/sass/src/_headers.sass
+++ b/assets/sass/src/_headers.sass
@@ -28,10 +28,11 @@ $-font_size_list: 2, 1.5, 1.17, 1, 0.83, 0.67
       margin-right: 0
       font-weight: bold
       // background-color: get_header_color($i)
-      text-shadow: 1px 1px 0 #6d2959
 
-      @if $i != 1
-        color: #ec22c0
+      text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb, 0 4px 0 #b9b9b9, 0 5px 0 #aaa, 0 6px 1px rgba(0,0,0,.1), 0 0 5px rgba(0,0,0,.1), 0 1px 3px rgba(0,0,0,.3), 0 3px 5px rgba(0,0,0,.2), 0 5px 10px rgba(0,0,0,.25), 0 10px 10px rgba(0,0,0,.2), 0 20px 20px rgba(0,0,0,.15)
+
+      // @if $i != 1
+      //  color: #ec22c0
 
       & a::before  // hi a::before
         content: "🔗"  // 在前面加上一個連結的符號

--- a/assets/sass/src/_headers.sass
+++ b/assets/sass/src/_headers.sass
@@ -44,6 +44,10 @@ $-font_size_list: 2, 1.5, 1.17, 1, 0.83, 0.67
       //  text-shadow: none
       //  color: initial
 
+  :target  // 文章內連結點擊過去的目標屬性設置
+    border: 2px solid #D4D4D4
+    background-color: #e5eecc
+
 @function get_header_color($layer)
   @if $layer == 1
     @return initial

--- a/assets/sass/src/_headers.sass
+++ b/assets/sass/src/_headers.sass
@@ -33,9 +33,12 @@ $-font_size_list: 2, 1.5, 1.17, 1, 0.83, 0.67
       @if $i != 1
         color: #ec22c0
 
+      & a::before  // hi a::before
+        content: "🔗"  // 在前面加上一個連結的符號
+
       & a
-        text-decoration: none  // 取消下畫線
-        color: inherit!important  // 使用header本身的顏色。(hover的顏色也會被弄掉，所以如果要有hover的效果顏色要重弄，且如果這邊用的是important那麼hover也要用important才有辦法覆蓋)
+        text-decoration: none   // 取消下畫線
+        color: inherit!important   // 使用header本身的顏色。(hover的顏色也會被弄掉，所以如果要有hover的效果顏色要重弄，且如果這邊用的是important那麼hover也要用important才有辦法覆蓋)
       & a:hover
         color: #96CCFF!important
 

--- a/assets/sass/src/fonts/fonts.sass
+++ b/assets/sass/src/fonts/fonts.sass
@@ -1,0 +1,5 @@
+@mixin init_google_fonts()
+  // https://fonts.google.com/specimen/Noto+Sans+TC?subset=chinese-traditional&preview.text=%E4%BB%96%E5%80%91%E3%80%82&preview.text_type=custom
+  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400&display=swap')
+  .google-noto-sans-tc
+    font-family: 'Noto Sans TC', sans-serif

--- a/assets/sass/src/fonts/fonts.sass
+++ b/assets/sass/src/fonts/fonts.sass
@@ -1,5 +1,5 @@
 @mixin init_google_fonts()
   // https://fonts.google.com/specimen/Noto+Sans+TC?subset=chinese-traditional&preview.text=%E4%BB%96%E5%80%91%E3%80%82&preview.text_type=custom
-  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400&display=swap')
-  .google-noto-sans-tc
-    font-family: 'Noto Sans TC', sans-serif
+  // @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400&display=swap')
+  // .google-noto-sans-tc
+  //  font-family: 'Noto Sans TC', sans-serif

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -105,7 +105,7 @@
   </head>
 
   {{/* safeHTMLAttr 沒有加上會出現 #ZgotmplZ 的字眼，這個字眼是固定的 */}}
-  <body {{ $body_spy_scroll_attr | safeHTMLAttr  }}  class="ma0 {{ $.Param `body_classes`  | default `avenir bg-near-white`}}{{ with getenv `HUGO_ENV` }} {{ . }}{{ end }}">
+  <body {{ $body_spy_scroll_attr | safeHTMLAttr  }}  class="ma0 {{ $.Param `body_classes`  | default ` bg-near-white`}} {{ partial `func/get-font-family-class` (slice `body` `avenir` . ) }}">
 
     {{- block "header" . -}}
       {{/* 包含頁面上方的featured_image、左上角的.Site.Params.site_logo、Menu清單  */}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -46,8 +46,8 @@
 
     {{- range .Site.Params.custom_css -}}
       {{/*
-      有了這個就可以 [params] custom_css = ["css/foo.css", "css/bar.css"]
-      指: static/css/{foo.css, bar.css}
+        有了這個就可以 [params] custom_css = ["css/foo.css", "css/bar.css"]
+        指: static/css/{foo.css, bar.css}
       */}}
       <link rel="stylesheet" href="{{- relURL (.) -}}">
     {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -60,7 +60,7 @@
         <span class="f6 mv4 dib tracked"> - {{ .WordCount}} words</span>
       {{ end }}
     </header>
-    <div class="nested-copy-line-height lh-copy {{ $.Param "post_content_classes"  | default "serif"}} f4 nested-links nested-img mid-gray
+    <div class="nested-copy-line-height lh-copy {{ $.Param `post_content_classes`  | default ``}} {{ partial `func/get-font-family-class` (slice `content` `serif` .) }} f4 nested-links nested-img mid-gray
     {{/* 把右側的padding拿掉 pr4-l */}}
     w-80-l"  {{/* w-two-thirds-l: https://tachyons.io/docs/layout/widths/ */}}
     >

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,7 +10,12 @@
 {{- end -}}
 
 {{- define "main" -}}
-  {{- $section := .Site.GetPage "section" .Section -}}
+  {{/*
+    Hugo 0.45以後已經不需要那麼麻煩的寫法
+      > https://gohugo.io/functions/getpage/
+    {{- $section := .Site.GetPage "section" .Section -}}
+  */}}
+  {{- $section := .Site.GetPage .Section -}}
   <article class="flex-l flex-wrap justify-between mw8 center ph3">
     {{/*
           https://getbootstrap.com/docs/4.4/utilities/spacing/
@@ -51,7 +56,7 @@
           3) A page front matter value is set `show_reading_time = true`
         */}}
       {{ if (or (eq (.Param "show_reading_time") true) (eq $section.Params.show_reading_time true) )}}
-        <span class="f6 mv4 dib tracked"> - {{ .ReadingTime}} minutes read</span>
+        <span class="f6 mv4 dib tracked"> - 🕒 {{ .ReadingTime}} minutes read</span>
         <span class="f6 mv4 dib tracked"> - {{ .WordCount}} words</span>
       {{ end }}
     </header>

--- a/layouts/custom_layout/site/navigation/pages-timeline.html
+++ b/layouts/custom_layout/site/navigation/pages-timeline.html
@@ -1,0 +1,110 @@
+{{/*
+USAGE:
+
+ xxx.md
+
+  +++
+  title="..."
+  date = ...
+  type = "custom_layout"
+  layout = "site/navigation/pages-timeline"
+  +++
+
+*/}}
+
+{{- define "head" }}
+  <link href="{{ relURL `css/timeline.css` }}" rel="stylesheet">
+  <script defer src="{{ relURL `js/auto-open-details.js` }}"></script>
+{{- end -}}
+
+{{/* <div class="container {{ cond (eq (mod ($cur_year | int) 2) 0) `left` `right` }}"> */}}
+
+{{- define "main" -}}
+  <section>
+    <div class="container">
+
+      {{/*
+      <section class="mt-3 row">
+        <div class="col-md-3"></div>
+        <div class="col-md-6">
+          <h4>Timeline: By Create Date (YY → MM )</h4>
+        </div>
+        <div class="col-md-3"></div>
+      </section>
+      */}}
+
+      <section class="mt-3 row" style="max-height:90%;">
+        <div class="col-md-12">
+          <div class="main-timeline">
+            <div class="timeline"></div>
+
+            {{- range .Site.RegularPages.GroupByDate "2006" -}}
+              {{- $cur_year := .Key -}}
+              <div class="timeline">
+                <div class="timeline-content">
+                  <span class="year">{{ $cur_year }}</span>
+                  <h3 class="title"></h3>
+                  <article class="description">
+                    <details>
+                      <summary>{{- $cur_year }} <small class="text-muted">{{- printf `(%d)` (len .Pages) -}}</small></summary>
+                      {{- $mm := 0 -}}
+                      {{- $need_end_node := false -}}
+                      {{- $all_pages := .Pages -}}
+
+                      {{- range .Pages -}}
+                        {{- $cur_date := dateFormat "2006-01-02" .Date -}}
+                        {{- $cur_date_yy_mm_dd := split $cur_date "-" -}}
+                        {{- $cur_mm := index $cur_date_yy_mm_dd 1 -}}
+
+                        {{/* 此區決定月份。開頭為0或者月份不同時都要放置新的月份 */}}
+                        {{- if or (eq $mm 0) (ne $cur_mm $mm) -}}
+                          {{- $need_end_node = true -}}  {{/* 通知外層(換新的一年時) */}}
+
+                          {{- if ne $mm 0 -}}
+                            </ul></details>  {{/* 放置新的月份如果月份不為0就要先結束掉之前殘留的月份 */}}
+                          {{- end -}}
+
+                          {{- $count_month_items := 0 -}} {{/* 此區段計算該月份總共有多少文章 */}}
+                          {{- range $.Site.RegularPages.GroupByDate "2006-01" -}}
+                            {{- range .Pages -}}
+                              {{- $temp_cur_date := dateFormat "2006-01-02" .Date -}}
+                              {{- $temp_cur_date_yy_mm_dd := split $temp_cur_date "-" -}}
+                              {{- $temp_yy := index $temp_cur_date_yy_mm_dd 0 -}}
+                              {{- $temp_mm := index $temp_cur_date_yy_mm_dd 1 -}}
+                              {{- if and (eq $temp_mm $cur_mm) (eq $temp_yy $cur_year) -}}
+                                {{- $count_month_items = add $count_month_items 1 -}}
+                              {{- end -}}
+                            {{- end -}}
+                          {{- end -}}
+
+                          <details><summary>{{- $cur_mm }} <small class="text-muted">{{- printf `(%d)` $count_month_items -}}</small></summary>
+                            <ul>
+                              {{- $mm = $cur_mm -}}
+                        {{- end -}}
+
+                        {{/* 決定月份內中的資料 */}}
+                        <li>
+                          <div>
+                            <a href="{{ .Permalink }}">{{ .Title }}</a>
+                            <small class="text-muted"><time>{{ .Date.Format "2006-01-02" }}</time></small>
+                          </div>
+                        </li>
+                      {{- end -}}
+
+                      {{/* 離開所有月份時，如果月份中含有資料就要補上結尾 */}}
+                      {{- if $need_end_node -}}
+                        </ul></details>
+                      {{- end -}}
+                    </details>
+                  </article>
+                </div>
+              </div>
+            {{- end -}}
+
+
+          </div>
+        </div>
+      </section>
+    </div>
+  </section>
+{{- end -}}

--- a/layouts/custom_layout/site/navigation/site-tree.html
+++ b/layouts/custom_layout/site/navigation/site-tree.html
@@ -119,8 +119,10 @@
             {{- end -}}
 
             <li>
-              <a href="{{ .Permalink }}">{{ .Title }}</a>
-              <div><time>{{ .Date.Format "2006-01-02" }}</time></div>
+              <div>
+                <a href="{{ .Permalink }}">{{ .Title }}</a>
+                <small class="text-muted"><time>{{ .Date.Format "2006-01-02" }}</time></small>
+              </div>
             </li>
         {{- end -}}
 

--- a/layouts/partials/card-post-bs.html
+++ b/layouts/partials/card-post-bs.html
@@ -4,7 +4,7 @@ create a post card with the bootstrap.
 
 {{- $article_image := default "" .Params.article_image -}}
 {{- $font_color := default "" .Params.article_image -}}
-<section class="zoom-in mt4 card" style="width: 20rem;">
+<section class="zoom-in mt4 card" style="width:20rem;">
   {{- $bg_color := "bg-light" -}}
   {{- $btn_color := "btn-primary" -}}
   {{- $text_muted_color := "text-muted" -}}
@@ -26,7 +26,7 @@ create a post card with the bootstrap.
   {{ $bg_color }}
   {{ cond (in (slice `bg-warning` `bg-light` `bg-white`) $bg_color) `black` `white`}}
   ">
-    <a class="link dim" href="{{.Permalink}}" style="color: inherit;"><h3 class="card-title">{{- .Title -}}</h3></a>
+    <a class="link dim" href="{{.Permalink}}" style="color: inherit;"><h3 class="card-title" style="color:initial; text-shadow:none;">{{- .Title -}}</h3></a>
     <p class="card-text">{{- default .Summary .Description -}}</p>
     <a href="{{.Permalink}}" class="btn {{$btn_color}}">{{ i18n "readMore" }}</a>
     {{with .Date}}<p class="card-text"><small class="{{$text_muted_color}} float-end">{{ .Format "2006, Jan 2, Mon " }}</small></p>{{end}}

--- a/layouts/partials/func/get-font-family-class.html
+++ b/layouts/partials/func/get-font-family-class.html
@@ -1,0 +1,11 @@
+{{- $target := index . 0 -}}
+{{- $default := index . 1 -}}
+{{- $page := index . 2 -}}
+
+{{- $fonts := $page.Param "fonts" -}}
+
+{{- $fontClass := $default -}}
+{{- with $fonts.class -}}
+  {{- $fontClass = index . $target -}}
+{{- end -}}
+{{- return $fontClass -}}

--- a/layouts/partials/func/get-font-family-class.html
+++ b/layouts/partials/func/get-font-family-class.html
@@ -1,3 +1,31 @@
+{{/*
+在baseof.html中有寫道.Site.Params.custom_css
+因此可以加入自定義的css在static
+
+## google-fonts.css
+  // google fonts可參考: https://fonts.google.com/specimen/Noto+Sans+TC?subset=chinese-traditional&preview.text=%E4%BB%96%E5%80%91%E3%80%82&preview.text_type=custom
+  .mindmap a {
+    font-family: Noto Sans TC, cursive, sans-serif!important; // 對markmap的文字進行更改
+  }
+
+  .google-noto-sans-tc {  // 建立一個新的class為了指定字型的class用
+    font-family: "Noto Sans TC", sans-serif;
+  }
+
+## config.toml
+
+  [params]
+    custom_css = [
+      "css/google-fonts.css",  # 放入自定義的css。可以參考以上的css當作範例
+    ]
+  [params.fonts]
+    [params.fonts.class]
+      # 指定您的css名稱。目前共有三個作用域
+      h1 = "google-noto-sans-tc"
+      body = "google-noto-sans-tc"
+      content = "google-noto-sans-tc"
+*/}}
+
 {{- $target := index . 0 -}}
 {{- $default := index . 1 -}}
 {{- $page := index . 2 -}}

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -7,9 +7,9 @@
       {{- partial "site-navigation.html" . -}}
       <div class="tc-l pv6 ph3 ph4-ns">
         {{- if not .Params.omit_header_text -}}
-          <h1 class="f2 f1-l fw2 white-90 mb0 lh-title">{{ .Title | default .Site.Title }}</h1>
+          <h1 class="f2 f1-l white-90 mb0 lh-title">{{ .Title | default .Site.Title }}</h1>
           {{- with .Params.description  -}}
-            <h2 class="fw1 f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4"
+            <h2 class="f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4"
                 style="background-color:initial;"
             >
               {{- . -}}

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -17,11 +17,11 @@
     >
       {{- partial "site-navigation.html" . -}}
       <div class="tc-l pv4 pv6-l ph3 ph4-ns">
-        <h1 class="f2 f-subheadline-l fw2 white-90 mb0 lh-title">
+        <h1 class="f2 f-subheadline-l white-90 mb0 lh-title">
           {{- default .Site.Title .Title -}}  {{/* 如果網站的front matter已經有宣告title就以他為主，否則就使用.Site.Title */}}
         </h1>
         {{- with .Params.description -}}
-          <h2 class="fw1 f5 f3-l white-80 measure-wide-l center mt3"
+          <h2 class="f5 f3-l white-80 measure-wide-l center mt3"
               style="background-color:initial;">
             {{- . -}}
           </h2>
@@ -35,11 +35,11 @@
     <div class="pb3-m pb6-l {{ .Site.Params.background_color_class | default "bg-black" }}">
       {{- partial "site-navigation.html" . -}}  {{/* 掌管Menu，包含主題頁左上角的site_logo */}}
       <div class="tc-l pv3 ph3 ph4-ns">
-        <h1 class="f2 f-subheadline-l fw2 light-silver mb0 lh-title">
+        <h1 class="f2 f-subheadline-l light-silver mb0 lh-title">
           {{- default .Site.Title .Title -}}  {{/* 頁面頂部中間區域的文字 */}}
         </h1>
         {{- with .Params.description -}}
-          <h2 class="fw1 f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4"
+          <h2 class="f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4"
               style="background-color:initial;">
             {{- . -}}
           </h2>

--- a/layouts/partials/summary-with-image.html
+++ b/layouts/partials/summary-with-image.html
@@ -12,7 +12,7 @@
         </div>
       {{- end -}}
       <div class="blah w-100{{ if $featured_image }} w-60-ns pl3-ns{{ end }}">
-        <h1 class="f3 fw1 athelas mt0 lh-title">
+        <h1 class="f3 {{ partial `func/get-font-family-class` (slice `h1` `athelas` .) }} mt0 lh-title">
           <a href="{{.Permalink}}" class="color-inherit dim link">
             {{- .Title -}}
             </a>

--- a/layouts/post/summary-with-image.html
+++ b/layouts/post/summary-with-image.html
@@ -8,7 +8,7 @@
         </div>
       {{ end }}
       <div class="w-100{{ if $featured_image }} w-60-ns pl3-ns{{ end }}">
-        <h1 class="f3 fw1 athelas mt0 lh-title">{{ .Title }}</h1>
+        <h1 class="f3 {{ partial `func/get-font-family-class` (slice `h1` `athelas` .) }} mt0 lh-title">{{ .Title }}</h1>
         <div class="f6 f5-l lh-copy nested-copy-line-height">
           {{ .Summary }}
         </div>

--- a/layouts/shortcodes/btn/download.go.html
+++ b/layouts/shortcodes/btn/download.go.html
@@ -1,0 +1,6 @@
+{{/*
+usage:
+  {{< btn/download "https://www.postgresql.org/download/" "download" "2x" >}}
+*/}}
+
+<a href="{{ .Get 0 }}" title="{{- .Get 1 -}}"><span class="fas fa-download {{ cond (gt (len ( .Get 2 )) 0)   (printf `fa-%s` (.Get 2) ) ``  -}}"></span></a>

--- a/layouts/shortcodes/set-id.html
+++ b/layouts/shortcodes/set-id.html
@@ -1,1 +1,11 @@
+{{/*
+  USAGE:
+
+    {{< set-id "三個資料表" "他要這三個資料表">}}
+
+    [準備資料]({{<ref "#三個資料表" >}})
+
+  如果這個您覺得麻煩，可以參考另一個shortcode: auto-id
+*/}}
+
 <span id={{ (.Get 0) }}>{{ .Get 1 | markdownify }}</span>

--- a/layouts/shortcodes/table/code-by-example.html
+++ b/layouts/shortcodes/table/code-by-example.html
@@ -44,7 +44,7 @@ USAGE:
       <div class="as_table-container-col">
     {{- end -}}
         {{- if index $col_attr_info 0 -}}
-          <h2 style="background-color:initial">{{- index $col_attr_info 0 -}}</h2>
+          <h2 style="color:initial; text-shadow:none">{{- index $col_attr_info 0 -}}</h2>
         {{- end -}}
 
         {{- if (findRE "<pre" $contents 1) -}}

--- a/static/css/markmap.css
+++ b/static/css/markmap.css
@@ -5,7 +5,7 @@
 
 .mindmap a {
   /* font-family: "Font Awesome 5 Free",  */
-  font-family: cursive, sans-serif;
+  font-family: Noto Sans TC, cursive, sans-serif;
   font-size: 0.8em;
   text-decoration: none;
 }

--- a/static/css/timeline.css
+++ b/static/css/timeline.css
@@ -1,0 +1,35 @@
+:is(h1, h2, h3, h4, h5, h6) {background-color: initial;}
+.main-timeline{overflow:hidden;position:relative;}
+.main-timeline:before{content:"";width:10px;height:100%;border:3px solid #959595;position:absolute;top:40px;left:50%;transform:translateX(-50%)}  /* timeline的直線 */
+.main-timeline .timeline{width:50%;padding:10px 60px 10px 100px;float:right;position:relative;}  /* 方塊本體 */
+.main-timeline .timeline:before{content:"";width:40px;height:40px;border-radius:50%;background:#00DAFF;border:5px solid #fff;box-shadow:0 0 1px 5px #00DAFF;position:absolute;top:42px;left:-20px}  /* 小圓圈 */
+.main-timeline .timeline-content{display:block;background:#e9e9e7;padding:70px 30px 20px;box-shadow:0 0 10px rgba(0,0,0,.2) inset;position:relative}  /* 方塊本體中的文本區塊 */
+.main-timeline .timeline-content:hover{text-decoration:none}  /* 取消hover時出現的下畫線 */
+.main-timeline .year{display:block;width:80%;height:50px;background:#00DAFF;padding:0 0 0 50px;font-size:30px;font-weight:800;color:#fff;line-height:50px;box-shadow:0 0 20px rgba(0,0,0,.4) inset;border-radius:10px 10px 10px 0;position:absolute;top:20px;left:-20px}  /* 年份長條的外觀 */
+.main-timeline .year:before{content:"";border-top:40px solid #00DAFF;border-left:20px solid transparent;border-bottom:20px solid transparent;position:absolute;bottom:-60px;left:0}  /* 年份長條外觀底下多出來的三角形 */
+.main-timeline .title{font-size:18px;font-weight:600;text-transform:uppercase;color:#4a4a4a}
+.main-timeline .description{color:#6f6f6f;margin:0 0 5px}
+.main-timeline .timeline:nth-child(2n){padding:10px 100px 10px 60px;text-align:right}
+.main-timeline .timeline:nth-child(2n):before{left:auto;right:-20px;background:#bf3fc8;box-shadow:0 0 1px 5px #bf3fc8}
+.main-timeline .timeline:nth-child(2n) .year{padding-right:50px;border-radius:10px 10px 0;left:auto;right:-20px;background:#bf3fc8}
+.main-timeline .timeline:nth-child(2n) .year:before{border-left:none;border-right:20px solid transparent;left:auto;right:0;border-top-color:#bf3fc8}
+.main-timeline .timeline:nth-child(2){margin-top:140px}
+.main-timeline .timeline:nth-child(even){margin-bottom:60px}
+.main-timeline .timeline:nth-child(odd){margin:-140px 0 0}
+.main-timeline .timeline:first-child,.main-timeline .timeline:last-child:nth-child(even){margin:0}
+.main-timeline .timeline:nth-child(3n):before{background:#E37303;box-shadow:0 0 1px 5px #E37303}
+.main-timeline .timeline:nth-child(3n) .year{background:#E37303}
+.main-timeline .timeline:nth-child(3n) .year:before{border-top-color:#E37303}
+.main-timeline .timeline:nth-child(4n):before{background:#8cc43d;box-shadow:0 0 1px 5px #8cc43d}
+.main-timeline .timeline:nth-child(4n) .year{background:#8cc43d}
+.main-timeline .timeline:nth-child(4n) .year:before{border-top-color:#8cc43d}
+@media only screen and (max-width:990px){.main-timeline:before{top:8%}
+  .main-timeline .timeline{padding:10px 10px 10px 100px}
+  .main-timeline .timeline:nth-child(2n){padding:10px 100px 10px 10px}
+}
+@media only screen and (max-width:767px){.main-timeline:before{width:8px;top:0;left:12px;transform:translateX(0)}
+  .main-timeline .timeline,.main-timeline .timeline:nth-child(even),.main-timeline .timeline:nth-child(odd){width:100%;float:none;text-align:left;padding:0 0 0 60px;margin:0 0 30px}
+  .main-timeline .timeline:before,.main-timeline .timeline:nth-child(2n):before{width:20px;height:20px;border:3px solid #fff;top:38px;left:6px}
+  .main-timeline .timeline:nth-child(2n) .year{right:auto;left:-20px;border-radius:10px 10px 10px 0}
+  .main-timeline .timeline:nth-child(2n) .year:before{border-left:20px solid transparent;border-bottom:20px solid transparent;border-right:none;right:auto;left:0}
+}

--- a/static/dist/sass/main_sass.css
+++ b/static/dist/sass/main_sass.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400&display=swap");
 .mark-search {
   background-color: yellow;
   color: black;
@@ -211,8 +210,4 @@ kbd {
 
 .copy-code-button:active {
   background-color: #D9D9D9;
-}
-
-.google-noto-sans-tc {
-  font-family: "Noto Sans TC", sans-serif;
 }

--- a/static/dist/sass/main_sass.css
+++ b/static/dist/sass/main_sass.css
@@ -12,7 +12,7 @@ h1 {
   margin-left: 0;
   margin-right: 0;
   font-weight: bold;
-  text-shadow: 1px 1px 0 #6d2959;
+  text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb, 0 4px 0 #b9b9b9, 0 5px 0 #aaa, 0 6px 1px rgba(0, 0, 0, 0.1), 0 0 5px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.3), 0 3px 5px rgba(0, 0, 0, 0.2), 0 5px 10px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.2), 0 20px 20px rgba(0, 0, 0, 0.15);
 }
 h1 a::before {
   content: "🔗";
@@ -33,8 +33,7 @@ h2 {
   margin-left: 0;
   margin-right: 0;
   font-weight: bold;
-  text-shadow: 1px 1px 0 #6d2959;
-  color: #ec22c0;
+  text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb, 0 4px 0 #b9b9b9, 0 5px 0 #aaa, 0 6px 1px rgba(0, 0, 0, 0.1), 0 0 5px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.3), 0 3px 5px rgba(0, 0, 0, 0.2), 0 5px 10px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.2), 0 20px 20px rgba(0, 0, 0, 0.15);
 }
 h2 a::before {
   content: "🔗";
@@ -55,8 +54,7 @@ h3 {
   margin-left: 0;
   margin-right: 0;
   font-weight: bold;
-  text-shadow: 1px 1px 0 #6d2959;
-  color: #ec22c0;
+  text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb, 0 4px 0 #b9b9b9, 0 5px 0 #aaa, 0 6px 1px rgba(0, 0, 0, 0.1), 0 0 5px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.3), 0 3px 5px rgba(0, 0, 0, 0.2), 0 5px 10px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.2), 0 20px 20px rgba(0, 0, 0, 0.15);
 }
 h3 a::before {
   content: "🔗";
@@ -77,8 +75,7 @@ h4 {
   margin-left: 0;
   margin-right: 0;
   font-weight: bold;
-  text-shadow: 1px 1px 0 #6d2959;
-  color: #ec22c0;
+  text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb, 0 4px 0 #b9b9b9, 0 5px 0 #aaa, 0 6px 1px rgba(0, 0, 0, 0.1), 0 0 5px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.3), 0 3px 5px rgba(0, 0, 0, 0.2), 0 5px 10px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.2), 0 20px 20px rgba(0, 0, 0, 0.15);
 }
 h4 a::before {
   content: "🔗";
@@ -99,8 +96,7 @@ h5 {
   margin-left: 0;
   margin-right: 0;
   font-weight: bold;
-  text-shadow: 1px 1px 0 #6d2959;
-  color: #ec22c0;
+  text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb, 0 4px 0 #b9b9b9, 0 5px 0 #aaa, 0 6px 1px rgba(0, 0, 0, 0.1), 0 0 5px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.3), 0 3px 5px rgba(0, 0, 0, 0.2), 0 5px 10px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.2), 0 20px 20px rgba(0, 0, 0, 0.15);
 }
 h5 a::before {
   content: "🔗";
@@ -121,8 +117,7 @@ h6 {
   margin-left: 0;
   margin-right: 0;
   font-weight: bold;
-  text-shadow: 1px 1px 0 #6d2959;
-  color: #ec22c0;
+  text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb, 0 4px 0 #b9b9b9, 0 5px 0 #aaa, 0 6px 1px rgba(0, 0, 0, 0.1), 0 0 5px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.3), 0 3px 5px rgba(0, 0, 0, 0.2), 0 5px 10px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.2), 0 20px 20px rgba(0, 0, 0, 0.15);
 }
 h6 a::before {
   content: "🔗";

--- a/static/dist/sass/main_sass.css
+++ b/static/dist/sass/main_sass.css
@@ -116,6 +116,11 @@ h6 a:hover {
   color: #96CCFF !important;
 }
 
+:target {
+  border: 2px solid #D4D4D4;
+  background-color: #e5eecc;
+}
+
 table {
   font-size: 0.7em;
   border-top: 1px solid #666;

--- a/static/dist/sass/main_sass.css
+++ b/static/dist/sass/main_sass.css
@@ -11,7 +11,14 @@ h1 {
   margin-left: 0;
   margin-right: 0;
   font-weight: bold;
-  background-color: initial;
+  text-shadow: 1px 1px 0 #6d2959;
+}
+h1 a {
+  text-decoration: none;
+  color: inherit !important;
+}
+h1 a:hover {
+  color: #96CCFF !important;
 }
 
 h2 {
@@ -22,7 +29,15 @@ h2 {
   margin-left: 0;
   margin-right: 0;
   font-weight: bold;
-  background-color: bisque;
+  text-shadow: 1px 1px 0 #6d2959;
+  color: #ec22c0;
+}
+h2 a {
+  text-decoration: none;
+  color: inherit !important;
+}
+h2 a:hover {
+  color: #96CCFF !important;
 }
 
 h3 {
@@ -33,7 +48,15 @@ h3 {
   margin-left: 0;
   margin-right: 0;
   font-weight: bold;
-  background-color: bisque;
+  text-shadow: 1px 1px 0 #6d2959;
+  color: #ec22c0;
+}
+h3 a {
+  text-decoration: none;
+  color: inherit !important;
+}
+h3 a:hover {
+  color: #96CCFF !important;
 }
 
 h4 {
@@ -44,7 +67,15 @@ h4 {
   margin-left: 0;
   margin-right: 0;
   font-weight: bold;
-  background-color: bisque;
+  text-shadow: 1px 1px 0 #6d2959;
+  color: #ec22c0;
+}
+h4 a {
+  text-decoration: none;
+  color: inherit !important;
+}
+h4 a:hover {
+  color: #96CCFF !important;
 }
 
 h5 {
@@ -55,7 +86,15 @@ h5 {
   margin-left: 0;
   margin-right: 0;
   font-weight: bold;
-  background-color: bisque;
+  text-shadow: 1px 1px 0 #6d2959;
+  color: #ec22c0;
+}
+h5 a {
+  text-decoration: none;
+  color: inherit !important;
+}
+h5 a:hover {
+  color: #96CCFF !important;
 }
 
 h6 {
@@ -66,7 +105,15 @@ h6 {
   margin-left: 0;
   margin-right: 0;
   font-weight: bold;
-  background-color: bisque;
+  text-shadow: 1px 1px 0 #6d2959;
+  color: #ec22c0;
+}
+h6 a {
+  text-decoration: none;
+  color: inherit !important;
+}
+h6 a:hover {
+  color: #96CCFF !important;
 }
 
 table {

--- a/static/dist/sass/main_sass.css
+++ b/static/dist/sass/main_sass.css
@@ -130,9 +130,21 @@ h6 a:hover {
   color: #96CCFF !important;
 }
 
+@keyframes highlight-target {
+  from {
+    background: inherit;
+  }
+  50% {
+    border: 2px solid #D4D4D4;
+    background-color: #fff700;
+  }
+  to {
+    background: inherit;
+    border: inherit;
+  }
+}
 :target {
-  border: 2px solid #D4D4D4;
-  background-color: #e5eecc;
+  -webkit-animation: highlight-target 2s linear;
 }
 
 table {

--- a/static/dist/sass/main_sass.css
+++ b/static/dist/sass/main_sass.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400&display=swap");
 .mark-search {
   background-color: yellow;
   color: black;
@@ -210,4 +211,8 @@ kbd {
 
 .copy-code-button:active {
   background-color: #D9D9D9;
+}
+
+.google-noto-sans-tc {
+  font-family: "Noto Sans TC", sans-serif;
 }

--- a/static/dist/sass/main_sass.css
+++ b/static/dist/sass/main_sass.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 .mark-search {
   background-color: yellow;
   color: black;
@@ -12,6 +13,9 @@ h1 {
   margin-right: 0;
   font-weight: bold;
   text-shadow: 1px 1px 0 #6d2959;
+}
+h1 a::before {
+  content: "🔗";
 }
 h1 a {
   text-decoration: none;
@@ -32,6 +36,9 @@ h2 {
   text-shadow: 1px 1px 0 #6d2959;
   color: #ec22c0;
 }
+h2 a::before {
+  content: "🔗";
+}
 h2 a {
   text-decoration: none;
   color: inherit !important;
@@ -50,6 +57,9 @@ h3 {
   font-weight: bold;
   text-shadow: 1px 1px 0 #6d2959;
   color: #ec22c0;
+}
+h3 a::before {
+  content: "🔗";
 }
 h3 a {
   text-decoration: none;
@@ -70,6 +80,9 @@ h4 {
   text-shadow: 1px 1px 0 #6d2959;
   color: #ec22c0;
 }
+h4 a::before {
+  content: "🔗";
+}
 h4 a {
   text-decoration: none;
   color: inherit !important;
@@ -89,6 +102,9 @@ h5 {
   text-shadow: 1px 1px 0 #6d2959;
   color: #ec22c0;
 }
+h5 a::before {
+  content: "🔗";
+}
 h5 a {
   text-decoration: none;
   color: inherit !important;
@@ -107,6 +123,9 @@ h6 {
   font-weight: bold;
   text-shadow: 1px 1px 0 #6d2959;
   color: #ec22c0;
+}
+h6 a::before {
+  content: "🔗";
 }
 h6 a {
   text-decoration: none;

--- a/static/js/auto-open-details.js
+++ b/static/js/auto-open-details.js
@@ -1,0 +1,40 @@
+function getDetails(mouseEvent) {
+  let target = mouseEvent.target
+  if (target.tagName === 'SUMMARY') {
+    target = target.parentNode
+  }
+  if (target.tagName !== 'DETAILS') {
+    return  // Using return without a value will return the value undefined.
+  }
+  return target
+}
+
+(
+  ()=>{
+    const detailsCollection = document.getElementsByTagName('details')
+    for (let [key, details] of Object.entries(detailsCollection)){
+      details.onmouseover = (mouseEvent) => {
+        const target = getDetails(mouseEvent)
+        if (typeof target != "undefined") {
+          target.open = true
+        }
+      }
+      /*  不能這樣做，這樣會一離開該元素馬上就關閉了
+      details.onmouseout = (mouseEvent) => {
+        const target = getDetails(mouseEvent)
+        if (typeof target != "undefined") {
+          target.open = false
+        }
+      }
+       */
+    }
+    document.addEventListener('mouseover', (mouseEvent)=>{
+      for (let [key, details] of Object.entries(detailsCollection)){
+        if (details.matches(':hover')){
+          return  // 不用continue，原因是如果這個項目正在hover之中，那他的子項目是不需要被關閉的，所以用return讓他不被關起來
+        }
+        details.open = false
+      }
+    })
+  }
+)();


### PR DESCRIPTION
## Fix Bug
快速導覽的圖示名稱不正確 #1
## Enhancement
- 讓使用者可以透過config.toml來指定font-family所使用的class (#11)
     - 目前可以針對: {h1, body, content} 等三類做調整
     - 您如果要導入google fonts也是可以，可以參考: https://fonts.google.com/
- 增加了target的特效(動畫)，使得target可以更被容易查覺 (#13)
- h1~h6的header，把背景顏色去除改用text-shadow來突顯 (#14)
- 在連結前面(::before)新增了🔗，以代替下畫線(text-decoration) (#15)

## Features
- 新增了timeline的時間軸，可以看出文章的建立時間順序關系 (#12)
